### PR TITLE
Soften the code colors, and add light background

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -8,7 +8,7 @@
     <meta name="generator" content="{{ eleventy.generator }}">
 
     <link rel="stylesheet" href="{{ '/css/index.css' | url }}">
-    <link rel="stylesheet" href="{{ '/css/prism-base16-monokai.dark.css' | url }}">
+    <link rel="stylesheet" href="{{ '/css/prism-base16-atelierlakeside.light.css' | url }}">
     <link rel="stylesheet" href="{{ '/css/prism-diff.css' | url }}">
     <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">
     <link rel="alternate" href="{{ metadata.jsonfeed.path | url }}" type="application/json" title="{{ metadata.title }}">

--- a/browser-fetching/index.md
+++ b/browser-fetching/index.md
@@ -16,8 +16,10 @@ It's useful to web developers in scenarios such as:
 
 * **Displaying dynamic data** that changes over time.  
   _For example, fetching current weather conditions for the given location_
+
 * **Partially updating the page** in response to user interactivity.  
   _For example, fetching and displaying the current stock price for a user-provided stock index_
+
 * **Submitting forms** and displaying a success or error messages without needing to reload an entire page.  
   _For example, adding an item to a shopping cart_
 

--- a/css/index.css
+++ b/css/index.css
@@ -5,6 +5,8 @@
   --darkgray: #333;
   --navy: #17050F;
   --blue: #082840;
+  --light-blue: #ebf8ff;
+  --complementary-green: #08403C;
   --white: #fff;
 }
 
@@ -19,7 +21,17 @@ body {
   margin: 0;
   font-family: -apple-system, system-ui, sans-serif;
   color: var(--darkgray);
-  background-color: var(--white);
+  background-color: var(--light-blue);
+}
+body {
+  display: grid;
+  grid-template-columns: 1fr min(70rem, 90%) 1fr;
+}
+body > * {
+  grid-column: 2;
+}
+h1, h2, h3, h4, h5, h6 {
+  color: var(--complementary-green);
 }
 p:last-child {
   margin-bottom: 0;
@@ -40,6 +52,7 @@ a[href]:visited {
   color: var(--navy);
 }
 main {
+  background-color: var(--white);
   padding: 1rem;
 }
 main :first-child {
@@ -84,6 +97,7 @@ pre {
   padding: 1em;
   margin: .5em 0;
   background-color: #f6f6f6;
+  outline: 1px dashed var(--complementary-green);
 }
 code {
   word-break: break-all;

--- a/css/prism-base16-atelierlakeside.light.css
+++ b/css/prism-base16-atelierlakeside.light.css
@@ -1,0 +1,165 @@
+/*
+
+Name:       Base16 Atelier Lakeside Light
+Author:     Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/)
+
+Prism template by Bram de Haan (http://atelierbram.github.io/syntax-highlighting/prism/)
+Original Base16 color scheme by Chris Kempson (https://github.com/chriskempson/base16)
+
+*/
+code[class*="language-"],
+pre[class*="language-"] {
+  font-family: Consolas, Menlo, Monaco, "Andale Mono WT", "Andale Mono", "Lucida Console", "Lucida Sans Typewriter", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Liberation Mono", "Nimbus Mono L", "Courier New", Courier, monospace;
+  font-size: 14px;
+  line-height: 1.375;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+  background: #ebf8ff;
+  color: #516d7b;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+  text-shadow: none;
+  background: #c1e4f6;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+  text-shadow: none;
+  background: #c1e4f6;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+  padding: 1em;
+  margin: .5em 0;
+  overflow: auto;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+  padding: .1em;
+  border-radius: .3em;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #7195a8;
+}
+
+.token.punctuation {
+  color: #516d7b;
+}
+
+.token.namespace {
+  opacity: .7;
+}
+
+.token.operator,
+.token.boolean,
+.token.number {
+  color: #935c25;
+}
+
+.token.property {
+  color: #8a8a0f;
+}
+
+.token.tag {
+  color: #257fad;
+}
+
+.token.string {
+  color: #2d8f6f;
+}
+
+.token.selector {
+  color: #6b6bb8;
+}
+
+.token.attr-name {
+  color: #935c25;
+}
+
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #2d8f6f;
+}
+
+.token.attr-value,
+.token.keyword,
+.token.control,
+.token.directive,
+.token.unit {
+  color: #568c3b;
+}
+
+.token.statement,
+.token.regex,
+.token.atrule {
+  color: #2d8f6f;
+}
+
+.token.placeholder,
+.token.variable {
+  color: #257fad;
+}
+
+.token.deleted {
+  text-decoration: line-through;
+}
+
+.token.inserted {
+  border-bottom: 1px dotted #161b1d;
+  text-decoration: none;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+
+.token.important {
+  color: #d22d72;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+pre > code.highlight {
+  outline: 0.4em solid #d22d72;
+  outline-offset: .4em;
+}
+
+.line-numbers .line-numbers-rows {
+  border-right-color: #c1e4f6 !important;
+}
+
+.line-numbers-rows > span:before {
+  color: #7ea2b4 !important;
+}
+
+.line-highlight {
+  background: rgba(22, 27, 29, 0.2) !important;
+  background: -webkit-linear-gradient(left, rgba(22, 27, 29, 0.2) 70%, rgba(22, 27, 29, 0)) !important;
+  background: linear-gradient(to right, rgba(22, 27, 29, 0.2) 70%, rgba(22, 27, 29, 0)) !important;
+}

--- a/index.njk
+++ b/index.njk
@@ -1,8 +1,5 @@
 ---
 layout: layouts/home.njk
-eleventyNavigation:
-  key: Home
-  order: 1
 ---
 {% set maxPosts = collections.Latestposts.length | min(3) %}
 


### PR DESCRIPTION
### Summary

This is an attempt at applying a "Light Nature Theme" suggested in #82 
I am **not** a designer, but found complementary colors of the existing `blue` and `navy` colors, and tried to make some small but impactful changes to soften the pages with natural colors.

More specifically:
* Added a "lakeside light" css theme to the `code` renderings
* Added some margin around the `main` content.
* Added a light blue background.

As with Art, design is subjective. I will **not** be offended if either of you don't care for these design choices.

### What kind of change does this PR introduce?

- [x] Bug fix

Related issue: #82

### How to verify locally

1. `npm start`
1. http://localhost:8080/
 

**Expected results**:
Design should be less intimidating and more calming.
### Design Before
![design-before](https://user-images.githubusercontent.com/101895/179430668-e81e6221-c47b-4498-a410-a9343c0ce63b.png)

### Design After
![designed-result](https://user-images.githubusercontent.com/101895/179430402-087732f1-1045-46e7-ad69-75196d5db5ee.png)



