### PR TITLE
Add Learn index page and link in the main navigation

### DIFF
--- a/learn/analytes/index.md
+++ b/learn/analytes/index.md
@@ -2,9 +2,6 @@
 layout: layouts/experiment-graphing.njk
 title: Analytes
 templateClass: tmpl-experiment-graphing.njk
-eleventyNavigation:
-  key: Analytes
-  order: 5
 ---
 
 ### Testing injecting data and graphing that data.

--- a/learn/browser-fetching/index.md
+++ b/learn/browser-fetching/index.md
@@ -1,9 +1,6 @@
 ---
 layout: layouts/base.njk
 title: How to fetch data using a web browser
-eleventyNavigation:
-  key: Fetch
-  order: 2
 ---
 
 # Aren't you fetching?!

--- a/learn/index.md
+++ b/learn/index.md
@@ -3,7 +3,7 @@ layout: layouts/base.njk
 title: Learning modules
 eleventyNavigation:
   key: Learn
-  order: 3
+  order: 4
 ---
 
 # Learning Modules

--- a/learn/index.md
+++ b/learn/index.md
@@ -1,0 +1,12 @@
+---
+layout: layouts/base.njk
+title: Learning modules
+eleventyNavigation:
+  key: Learn
+  order: 3
+---
+
+# Learning Modules
+
+* [Fetching in the browser](./browser-fetching/)
+* [Analytes](./analytes/)


### PR DESCRIPTION
### Summary

This moves the Fetch and Analytes pages to a Learn index page. The navigation is more cohesive now, thanks @ingrey1 


### What kind of change does this PR introduce?

- [x] Add a new feature/page


### How to verify locally

1. `npm start`
1. http://localhost:8080/
 

**Expected results**:

![learn-page](https://user-images.githubusercontent.com/101895/180589596-f3d0db27-1e6d-48d5-aaf9-90a7b5a5a711.png)

